### PR TITLE
Allow all hosts

### DIFF
--- a/netbox-all.yaml
+++ b/netbox-all.yaml
@@ -157,7 +157,7 @@ kind: ConfigMap
 metadata:
   name: netbox-netbox-env
 data:
-  ALLOWED_HOSTS: localhost 0.0.0.0 127.0.0.1 [::1] netbox nginx netboxdocker.docker nginx.netboxdocker.docker
+  ALLOWED_HOSTS: '*'
   DB_HOST: postgres
   DB_NAME: netbox
   DB_PASSWORD: J5brHrAXFLQSif0K


### PR DESCRIPTION
This should explain everything you need to know
https://netbox.readthedocs.io/en/latest/configuration/mandatory-settings/#allowed_hosts

If you want to just make netbox universally accessible you do
`ALLOWED_HOSTS: "*"`

If the netbox pod has to be reachable through a specific domain name (ex. netboxinstance10.mysite.com) then you have to do
`ALLOWED_HOSTS: "netboxinstance10.mysite.com"`

With multiple values
`ALLOWED_HOSTS: "192.168.0.50 netboxinstance10.mysite.com"`