### PR TITLE
Using Latest-LDAP build to allow CI pipeline

### DIFF
--- a/netbox-all.yaml
+++ b/netbox-all.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: netbox
-        image: ninech/netbox:v2.2.6
+        image: ninech/netbox:latest-ldap
         ports:
         - containerPort: 8001
         env:


### PR DESCRIPTION
Hey @vishnoisuresh,

Using Latest-LDAP build to allow CI pipeline from https://hub.docker.com/r/ninech/netbox to flow on through, PR with ninech/netbox-docker: https://github.com/ninech/netbox-docker/pull/111

This will allow enabled CI based docker image to use additional module and then enable Kubernetes image that requires the previous docker image to have additional module.

Please review and approve.

~Haji